### PR TITLE
Implementation of File::Fcntl for access of ETag and Cache-Control attributes

### DIFF
--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -250,6 +250,34 @@ File::Stat(bool                    /*force*/,
 }
 
 XrdCl::XRootDStatus
+File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
+           timeout_t               timeout)
+{
+    // AMT, do we need this condition ?
+    if (!m_is_opened) {
+        m_logger->Error(kLogXrdClCurl, "Cannot stat.  URL isn't open");
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+    }
+    auto obj = new XrdCl::AnyObject();
+
+    // check here the query code from the handler
+    std::string as = arg.ToString();
+    XrdCl::QueryCode::Code code = (XrdCl::QueryCode::Code)std::stoi(as);
+    if (code == XrdCl::QueryCode::XAttr)
+    {
+        std::string etagRes;
+        m_logger->Debug(kLogXrdClCurl, "Going to access ETag");
+        GetProperty("ETag", etagRes);
+        XrdCl::Buffer* respBuff = new XrdCl::Buffer();
+        respBuff->FromString(etagRes);
+        obj->Set(respBuff);
+    }
+
+    handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+    return XrdCl::XRootDStatus();
+}
+
+XrdCl::XRootDStatus
 File::Read(uint64_t                offset,
            uint32_t                size,
            void                   *buffer,

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -257,42 +257,50 @@ XrdCl::XRootDStatus
 File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
            timeout_t               timeout)
 {
-    // AMT, do we need this condition ?
     if (!m_is_opened) {
-        m_logger->Error(kLogXrdClCurl, "Cannot stat.  URL isn't open");
+        m_logger->Error(kLogXrdClCurl, "Cannot run fcntl.  URL isn't open");
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
     }
-    auto obj = new XrdCl::AnyObject();
 
-    // check here the query code from the handler
+    auto obj = new XrdCl::AnyObject();
     std::string as = arg.ToString();
-    XrdCl::QueryCode::Code code = (XrdCl::QueryCode::Code)std::stoi(as);
-    if (code == XrdCl::QueryCode::XAttr)
+    try
     {
-        nlohmann::json xatt;
-        m_logger->Debug(kLogXrdClCurl, "Going to access ETag");
-        std::string etagRes;
-        if (GetProperty("ETag", etagRes)) {
-           xatt["ETag"] = etagRes;
-        }
-        std::string cc;
-        if (GetProperty("Cache-Control", cc))
+        XrdCl::QueryCode::Code code = (XrdCl::QueryCode::Code)std::stoi(as);
+        if (code == XrdCl::QueryCode::XAttr)
         {
-            if (cc.find("must-revalidate") != std::string::npos) {
-                xatt["revalidate"] = true;
+            nlohmann::json xatt;
+            std::string etagRes;
+            if (GetProperty("ETag", etagRes))
+            {
+                xatt["ETag"] = etagRes;
             }
-            static const std::regex rx("max-age=(\\d+)");
-            std::smatch m;
-            if (std::regex_search(cc, m, rx)) {
-                long int a = std::stol(m[1]);
-                time_t t = time(NULL) + a;
-                xatt["expire"] = t;
+            std::string cc;
+            if (GetProperty("Cache-Control", cc))
+            {
+                if (cc.find("must-revalidate") != std::string::npos)
+                {
+                    xatt["revalidate"] = true;
+                }
+                static const std::regex rx("max-age=(\\d+)");
+                std::smatch m;
+                if (std::regex_search(cc, m, rx))
+                {
+                    long int a = std::stol(m[1]);
+                    time_t t = time(NULL) + a;
+                    xatt["expire"] = t;
+                }
             }
+            XrdCl::Buffer *respBuff = new XrdCl::Buffer();
+            m_logger->Debug(kLogXrdClCurl, "Fcntl conent %s", xatt.dump().c_str());
+            respBuff->FromString(xatt.dump());
+            obj->Set(respBuff);
         }
-        XrdCl::Buffer* respBuff = new XrdCl::Buffer();
-        std::cout << "File::Fcntl " << xatt.dump(3) << "\n";
-        respBuff->FromString(xatt.dump());
-        obj->Set(respBuff);
+    }
+    catch (const std::exception& e)
+    {
+        m_logger->Warning(kLogXrdClCurl, "Failed to parse query code %s", e.what());
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errDataError);
     }
 
     handler->HandleResponse(new XrdCl::XRootDStatus(), obj);

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -282,13 +282,21 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
                 {
                     xatt["revalidate"] = true;
                 }
-                static const std::regex rx("max-age=(\\d+)");
-                std::smatch m;
-                if (std::regex_search(cc, m, rx))
+                size_t fm = cc.find("max-age=");
+                if (fm != std::string::npos)
                 {
-                    long int a = std::stol(m[1]);
-                    time_t t = time(NULL) + a;
-                    xatt["expire"] = t;
+                    fm += 9; // idx of the first character after the make-age= match
+                    for (size_t i = fm; i < cc.length(); i++)
+                    {
+                        if (!std::isdigit(cc[i]))
+                        {
+                            std::string sa = cc.substr(fm, i);
+                            long int a = std::stol(sa);
+                            time_t t = time(NULL) + a;
+                            xatt["expire"] = t;
+                            break;
+                        }
+                    }
                 }
             }
             XrdCl::Buffer *respBuff = new XrdCl::Buffer();

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -309,34 +309,34 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
         //
         else if (code == XrdCl::QueryCode::Stats)
         {
-             m_logger->Error(kLogXrdClCurl, "Server status query not supported.");
-             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+            m_logger->Error(kLogXrdClCurl, "Server status query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
         }
         else if (code == XrdCl::QueryCode::Checksum || code == XrdCl::QueryCode::ChecksumCancel)
         {
-             m_logger->Error(kLogXrdClCurl, "Checksum query not supported.");
-             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+            m_logger->Error(kLogXrdClCurl, "Checksum query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
         }
         else if (code == XrdCl::QueryCode::Config)
         {
             m_logger->Error(kLogXrdClCurl, "Server configuration query not supported.");
-             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
         }
         else if (code == XrdCl::QueryCode::Space)
         {
             m_logger->Error(kLogXrdClCurl, "Local space stats query not supported.");
-             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
         }
         else if (code == XrdCl::QueryCode::Opaque || code == XrdCl::QueryCode::OpaqueFile)
         {
             // XrdCl implementation dependent
             m_logger->Error(kLogXrdClCurl, "Opaque query not supported.");
-             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
         }
         else if (code == XrdCl::QueryCode::Prepare)
         {
             m_logger->Error(kLogXrdClCurl, "Prepare status query not supported.");
-             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
         }
         else
         {

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -304,6 +304,45 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
             respBuff->FromString(xatt.dump());
             obj->Set(respBuff);
         }
+        //
+        //   Query codes supported by  XrdCl::File::Fctnl
+        //
+        else if (code == XrdCl::QueryCode::Stats)
+        {
+             m_logger->Error(kLogXrdClCurl, "Server status query not supported.");
+             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Checksum || code == XrdCl::QueryCode::ChecksumCancel)
+        {
+             m_logger->Error(kLogXrdClCurl, "Checksum query not supported.");
+             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Config)
+        {
+            m_logger->Error(kLogXrdClCurl, "Server configuration query not supported.");
+             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Space)
+        {
+            m_logger->Error(kLogXrdClCurl, "Local space stats query not supported.");
+             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Opaque || code == XrdCl::QueryCode::OpaqueFile)
+        {
+            // XrdCl implementation dependent
+            m_logger->Error(kLogXrdClCurl, "Opaque query not supported.");
+             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Prepare)
+        {
+            m_logger->Error(kLogXrdClCurl, "Prepare status query not supported.");
+             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else
+        {
+            m_logger->Error(kLogXrdClCurl, "Invalid information query type code");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs);
+        }
     }
     catch (const std::exception& e)
     {

--- a/src/XrdClCurl/CurlFile.hh
+++ b/src/XrdClCurl/CurlFile.hh
@@ -71,6 +71,10 @@ public:
                                     XrdCl::ResponseHandler *handler,
                                     timeout_t               timeout) override;
 
+    virtual XrdCl::XRootDStatus Fcntl(const XrdCl::Buffer    &arg,
+                                    XrdCl::ResponseHandler *handler,
+                                    timeout_t               timeout) override;
+
     virtual XrdCl::XRootDStatus Read(uint64_t                offset,
                                     uint32_t                size,
                                     void                   *buffer,

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -49,7 +49,7 @@ CurlOpenOp::SetOpenProperties()
     if (url && m_file) {
         m_file->SetProperty("LastURL", url);
     }
-    // AMT, meed the ETag value here  for File::Fcntl query
+    // AMT, need the ETag value here  for File::Fcntl query
     // std::string etag = something.Get("ETag");
     //  m_file->SetProperty("ETag", etag);
 }

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -49,6 +49,9 @@ CurlOpenOp::SetOpenProperties()
     if (url && m_file) {
         m_file->SetProperty("LastURL", url);
     }
+    // AMT, meed the ETag value here  for File::Fcntl query
+    // std::string etag = something.Get("ETag");
+    //  m_file->SetProperty("ETag", etag);
 }
 
 void

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -23,7 +23,6 @@
 #include "../common/CurlResponseInfo.hh"
 #include "../common/CurlResponses.hh"
 
-#include <iostream>
 using namespace XrdClCurl;
 
 CurlOpenOp::CurlOpenOp(XrdCl::ResponseHandler *handler, const std::string &url, struct timespec timeout,

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -52,20 +52,13 @@ CurlOpenOp::SetOpenProperties()
         m_file->SetProperty("LastURL", url);
     }
 
-    auto hm = m_headers.RefHeaders();
-    ResponseInfo::HeaderValues hv = hm["Etag"];
-    if (!hv.empty())
+    if (!m_headers.GetETag().empty())
     {
-        // std::cout << "ETAG " << hv[0] << "\n";
-        std::string etag = hv[0];
+        std::string etag = m_headers.GetETag();
         etag.erase(remove(etag.begin(), etag.end(), '\"'), etag.end());
         m_file->SetProperty("ETag", etag);
     }
-    hv = hm["Cache-Control"];
-    if (!hv.empty())
-    {
-        m_file->SetProperty("Cache-Control", hv[0]);
-    }
+    m_file->SetProperty("Cache-Control", m_headers.GetCacheControl());
 }
 
 void

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -64,7 +64,6 @@ CurlOpenOp::SetOpenProperties()
     hv = hm["Cache-Control"];
     if (!hv.empty())
     {
-        // std::cout << "xxx Cache Control " << hv[0] << "\n";
         m_file->SetProperty("Cache-Control", hv[0]);
     }
 }

--- a/src/XrdClCurl/CurlUtil.cc
+++ b/src/XrdClCurl/CurlUtil.cc
@@ -379,6 +379,10 @@ bool HeaderParser::Parse(const std::string &header_line)
         m_location = header_value;
     } else if (header_name == "Digest") {
         ParseDigest(header_value, m_checksums);
+    } else if (header_name == "ETag") {
+        m_etag = header_value;
+    } else if (header_name == "Cache-Control") {
+        m_cache_control = header_value;
     }
 
     return true;

--- a/src/XrdClCurl/CurlUtil.hh
+++ b/src/XrdClCurl/CurlUtil.hh
@@ -125,6 +125,8 @@ public:
     // Convert a checksum type to a RFC 3230 digest name.
     static std::string ChecksumTypeToDigestName(XrdClCurl::ChecksumType type);
 
+    const ResponseInfo::HeaderMap& RefHeaders() const { return m_headers; }
+
 private:
 
     static bool validHeaderByte(unsigned char c);

--- a/src/XrdClCurl/CurlUtil.hh
+++ b/src/XrdClCurl/CurlUtil.hh
@@ -112,6 +112,8 @@ public:
     std::string GetStatusMessage() const {return m_resp_message;}
 
     const std::string &GetLocation() const {return m_location;}
+    const std::string &GetETag() const {return m_etag;}
+    const std::string &GetCacheControl() const {return m_cache_control;}
 
     // Returns a reference to the checksums parsed from the headers.
     const XrdClCurl::ChecksumInfo &GetChecksums() const {return m_checksums;}
@@ -124,8 +126,6 @@ public:
 
     // Convert a checksum type to a RFC 3230 digest name.
     static std::string ChecksumTypeToDigestName(XrdClCurl::ChecksumType type);
-
-    const ResponseInfo::HeaderMap& RefHeaders() const { return m_headers; }
 
 private:
 
@@ -145,6 +145,8 @@ private:
     std::string m_resp_message;
     std::string m_location;
     std::string m_multipart_sep;
+    std::string m_etag;
+    std::string m_cache_control;
 
     ResponseInfo::HeaderMap m_headers;
 


### PR DESCRIPTION
The CurlOpenOp::SetOpenProperties() is missing information. See the change.